### PR TITLE
Fix WECC240 model load failures: quoted clock times and conflicting gencost records

### DIFF
--- a/model/wecc240.glm
+++ b/model/wecc240.glm
@@ -14,8 +14,8 @@
 
 clock {
     timezone ${TIMEZONE};
-    starttime ${STARTTIME};
-    stoptime ${STOPTIME};
+    starttime "${STARTTIME}";
+    stoptime "${STOPTIME}";
 }
 
 module pypower
@@ -47,13 +47,14 @@ module pypower
 //
 // Load powerplant data
 //
+// The PSS/E converter already attaches one gencost to each gen (with zero
+// costs), so update those records instead of adding a second set, which
+// pypower rejects as conflicting gencost models.
+#for GENCOST in ${FIND class=gencost}
+modify ${GENCOST}.model POLYNOMIAL;
+modify ${GENCOST}.costs "${RANDOM triangle(0.001,0.01)},${RANDOM triangle(0,100)},0";
+#done
 #for GEN in ${FIND class=gen}
-object gencost
-{
-    parent ${GEN};
-    model POLYNOMIAL;
-    costs "${RANDOM triangle(0.001,0.01)},${RANDOM triangle(0,100)},0";
-}
 modify ${GEN}.Pmax 200;
 #done
 #for BRANCH in ${FIND class=branch}


### PR DESCRIPTION
This PR proposes fixes for the two load-time failures that stop `model/wecc240.glm` from running under current Arras Energy builds — an unquoted clock time expansion, and the conflicting gencost records reported in #63 (Fixes #63). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/208. You can sign in with your GitHub ID to claim ownership of the project.

## What happens today

The Simulation workflow is red on `main`, and it stops before a single object is loaded. Reproduced at `3f29a8d` in the same container the workflow uses (`Arras Energy 4.3.17-260810`):

```
$ docker run --rm -v $PWD:/app -w /app/model lfenergy/arras:develop gridlabd wecc240.glm
wecc240.glm(17): expected time value
FATAL    [INIT] : shutdown after command line rejected
$ echo $?
5
```

Line 17 is `starttime ${STARTTIME};`. `config.glm` defines it as `#define STARTTIME "2020-08-01 00:00:00 PST"`, and the macro value is now substituted *without* its surrounding quotes — `#print STARTTIME=${STARTTIME}` prints `STARTTIME=2020-08-01 00:00:00 PST` — so the clock block ends up with a bare, space-separated timestamp that the parser rejects. Quoting the expansion at the point of use is the same pattern already used further down for `costs "${RANDOM triangle(...)}"`. Only the two time values need it; `timezone ${TIMEZONE};` still parses, so it is left as-is.

With the clock block loading again, the run reaches INIT and reproduces #63 exactly:

```
WARNING  [INIT] : pypower OPF solver requires the number of gencost records (292) to match the number of gen records (146)
ERROR    [INIT] : wecc240_psse_G_1032_C: unable to add to different gencost models
ERROR    [INIT] : last error message was repeated 145 times
```

The cause is that the PSS/E converter now attaches a gencost to every gen by itself. Loading `wecc240_psse.raw` on its own and dumping the model gives 146 `gen` and 146 `gencost` objects, each already `model POLYNOMIAL` with `costs "0,0,0"`. The `#for GEN in ${FIND class=gen}` loop then creates a second gencost per gen, which is where 292 records and the conflicting-model rejection come from.

## The change

One file, `model/wecc240.glm`: quote the `starttime`/`stoptime` macro expansions, and set the cost curves on the gencost records that already exist rather than adding a parallel set. The `Pmax` override moves into its own loop over `gen` so it keeps applying to every generator.

## Verification

Same command, same image, before and after (the repo has no test suite, so the workflow's own command is the check):

- **Before:** parse failure at line 17, nothing loaded, exit 5.
- **After:** the model loads, INIT completes without the gencost warning or the repeated `unable to add to different gencost models` message, and the run proceeds to the first OPF solve.
- A model dump after the change has 146 `gencost` for 146 `gen` (was 292); every record is `POLYNOMIAL` with its own randomised curve — none left at `0,0,0` — and `Pmax` is 200 MW on all 146 generators, i.e. the original loop's intent is preserved.
- What this does **not** fix: the first solve at `2020-08-01 00:00:00 PST` still fails, with the solver writing bus voltage-limit violations across most of the network to `wecc240_failed.txt`. That is a modelling question rather than a load failure — it is the same with or without the `Pmax` override, and it only became visible once the model loads at all, which is presumably what #48 and #49 are aimed at.

## How this was managed

We imported this repository's issues and pull requests onto a board (87 stories, 5 labels) and worked this change on the story for #63: [story](https://eastagiletracker.com/projects/208/stories/72258), on the [board](https://eastagiletracker.com/projects/208).

![board](https://raw.githubusercontent.com/eastagiletracker/regrow/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
